### PR TITLE
feat: Docker-Composeを使用した起動方法とREADMEの追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# 基本イメージとして公式の .NET SDK イメージを使用
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# ソリューションファイルをコピーして復元
+COPY tvapp-bff.sln ./
+COPY Xiao.TVapp.Bff/*.csproj ./Xiao.TVapp.Bff/
+RUN dotnet restore
+
+# 残りのソースコードをコピーしてビルド
+COPY . ./
+RUN dotnet publish -c Release -o out
+
+# 実行環境として公式の .NET ランタイム イメージを使用
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# ビルド成果物をコピー
+COPY --from=build /app/out ./
+
+# yt-dlp のスタンドアロンバイナリをダウンロードしてインストール
+RUN apt-get update && apt-get install -y wget && \
+    wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux -O /usr/local/bin/yt-dlp && \
+    chmod a+rx /usr/local/bin/yt-dlp && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# アプリケーションを実行
+ENTRYPOINT ["dotnet", "Xiao.TVapp.Bff.dll"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+
+## 目次
+
+- [前提条件](#前条件)
+- [インストール](#インストール)
+- [使い方](#使い方)
+- [APIエンドポイント](#apiエンドポイント)
+- [開発](#開発)
+- [ライセンス](#ライセンス)
+
+## 前提条件
+
+このプロジェクトを実行するために必要な前提条件を以下に示します。
+
+- [.NET Core SDK](https://dotnet.microsoft.com/download) (.NET 7.0)
+- [Docker](https://www.docker.com/get-started)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+
+## インストール
+
+プロジェクトのクローンを作成します。
+
+```bash
+git clone https://github.com/hirotaka42/tvapp-bff.git
+cd tvapp-bff
+```
+
+## 使い方
+Docker Composeを使用してプロジェクトを起動します。
+```
+docker-compose up --build
+```
+
+Docker Composeを使用してプロジェクトを停止します。
+```
+docker-compose down
+```
+
+APIエンドポイントにアクセスするには、ブラウザまたはAPIクライアント（例: Postman）を使用して以下のURLにアクセスします。
+```
+http://localhost:8080/api/エンドポイント
+```
+
+## APIエンドポイント
+APIの主要なエンドポイントを以下に示します。
+
+### POST /api/TVapp/session
+- 説明: セッション時に作成される token を発行する
+- パラメータ: なし
+- レスポンス: `platformUid`と`platformToken`
+
+### GET /api/TVapp/ranking/{genre}
+- 説明: パラメータで受け取ったカテゴリ別のランキングを最大30個、取得する
+- パラメータ: 現在使用できるのは以下の6つ
+  - `drama`
+  - `variety`
+  - `anime`
+  - `news_documentary`
+  - `sports`
+  - `other`
+- レスポンス: 割愛
+
+### GET /api/TVapp/search
+- 説明: フリーワード検索
+- パラメータ: 
+  - `platformUid`
+  - `platformToken`
+  - `keyword`
+- レスポンス: 割愛
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  tvapp-bff:
+    image: tvapp-bff
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:80"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development


### PR DESCRIPTION
◼︎追加したライブラリ

- なし

◼︎変更概要
- [ ] README.mdの追加
- [ ] Docker-composeで起動できるようになった

◼︎使い方
Docker Composeを使用してプロジェクトを起動します。
```
docker-compose up --build
```

Docker Composeを使用してプロジェクトを停止します。
```
docker-compose down
```

APIエンドポイントにアクセスするには、ブラウザまたはAPIクライアント（例: Postman）を使用して以下のURLにアクセスします。
```
http://localhost:8080/api/エンドポイント
```