### PR TITLE
feat: セッショントークンを用いてホーム表示情報取得できるエンドポイントの実装

### DIFF
--- a/Xiao.TVapp.Bff/Controllers/TVappController.cs
+++ b/Xiao.TVapp.Bff/Controllers/TVappController.cs
@@ -109,6 +109,33 @@ namespace Xiao.TVapp.Bff.Controllers
             return Ok(content);
         }
 
+        [HttpGet("callHome")]
+        public async Task<IActionResult> CallHome([FromQuery] string platformUid, [FromQuery] string platformToken)
+        {
+            if ( string.IsNullOrWhiteSpace(platformUid) || string.IsNullOrWhiteSpace(platformToken))
+            {
+                return BadRequest("platformUid and platformToken are required");
+            }
+
+            var requestMessage = new HttpRequestMessage(
+                HttpMethod.Get,
+                $"https://platform-api.tver.jp/service/api/v1/callHome?platform_uid={platformUid}&platform_token={platformToken}");
+
+            requestMessage.Headers.Add("x-tver-platform-type", "web");
+            requestMessage.Headers.Add("Origin", "https://tver.jp");
+            requestMessage.Headers.Add("Referer", "https://tver.jp/");
+
+            var response = await client.SendAsync(requestMessage);
+            if (!response.IsSuccessStatusCode)
+            {
+                return StatusCode((int)response.StatusCode, "Failed to retrieve call results");
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+
+            return Ok(content);
+        }
+
         [HttpGet("streaming/{episodeId}")]
         public async Task<IActionResult> GetStreamingUrl(string episodeId)
         {


### PR DESCRIPTION
◼︎追加したライブラリ

- なし

◼︎エンドポイント名
```
/api/TVapp/callHome
```

◼︎クエリなどのパラメーター

```
platformUid
platformToken
```

◼︎想定されるResponse body
各ブロックで形式が全く異なるので整形は注意
![スクリーンショット 2024-06-07 22 20 18](https://github.com/hirotaka42/tvapp-bff/assets/79750434/9afd4d3e-3b99-4693-8bc2-39664f76fc2e)
